### PR TITLE
chore: Increase workflow interval schedule

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -6,7 +6,7 @@ on:
     tags: [ v* ]
   pull_request:
   schedule:
-  - cron: '0 */3 * * *'
+  - cron: '0 */6 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This workflow takes between 3 and 5 hours to execute. In some cases (e.g. https://github.com/ietf-tools/relaton-data-ids/actions/runs/5539700257) a workflow run starts before the previous run is completed. This causes data inconsistency issues when the latter workflow runs.

It makes sense to either increase the interval between each workflow (e.g. this PR increases it to 6 hours), or schedule it to run periodically once a day, like it's done in the relaton org (https://github.com/relaton/relaton-data-ids/blob/52b1dd9bc2cb2c2c70d6dbfcf4893838ef6f00ae/.github/workflows/crawler.yml#L11).

@kesara any thoughts on this one? I see you recently changed the interval schedule to 3 hours, so maybe there are reasons I am not aware of for such a change. 