### PR TITLE
chore: remove data directories before fetching new data

### DIFF
--- a/crawler.rb
+++ b/crawler.rb
@@ -3,4 +3,8 @@ require 'fileutils'
 system("rsync -avcizxL rsync.ietf.org::bibxml-ids ./bibxml-ids")
 
 require "relaton_ietf"
+
+FileUtils.rm Dir.glob("index*")
+FileUtils.rm_rf "data"
+
 RelatonIetf::DataFetcher.fetch "ietf-internet-drafts"


### PR DESCRIPTION
The issue described at https://github.com/ietf-tools/bibxml-service/issues/381 was fixed with the release [v1.12.6](https://github.com/relaton/relaton-ietf/releases/tag/v1.12.6) of the relaton-ietf Gem.

The crawler itself is not generating this document anymore. This document is tangling there from a run of an older version of relaton-ietf.

This PR aims at removing old data before each crawler run.