### PR TITLE
chore: Change GHA run every 4 hours.

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -6,7 +6,7 @@ on:
     tags: [ v* ]
   pull_request:
   schedule:
-  - cron: '0 */3 * * *'
+  - cron: '0 */4 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Too many failures since workflow takes more than 3 hours to complete.