### PR TITLE
fix: Ensure a single crawler workflow runs at a time

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -9,6 +9,10 @@ on:
   - cron: '0 */4 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: crawler
+  cancel-in-progress: false
+
 jobs:
   crawl:
     uses: relaton/support/.github/workflows/crawler.yml@master


### PR DESCRIPTION
See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency